### PR TITLE
Use booleans instead of strings for group check

### DIFF
--- a/server.js
+++ b/server.js
@@ -69,9 +69,9 @@ function checkIDs(res, group, netid)
 	for(var i = 0; i < group.netids.length; i++)
 	{
 		if(group.netids[i] == netid)
-			return res.json({"netid": netid, "isValid" : "true"});
+			return res.json({"netid": netid, "isValid" : true});
 	}
-	return res.json({"isValid" : "false"});
+	return res.json({"isValid" : false});
 }
 
 app.get("/groups/:groupType/:groupName", function(req, res){


### PR DESCRIPTION
Should use boolean values in JSON return, not strings.

This check is also a bit messy, but we can refactor later.